### PR TITLE
Refactor model loading

### DIFF
--- a/microwakeword/feature_generation.py
+++ b/microwakeword/feature_generation.py
@@ -396,7 +396,7 @@ class ClipsHandler:
 
         assert max_samples_from_end > len(x)
 
-        samples_from_end = np.random.randint(len(x), max_samples_from_end + 1)
+        samples_from_end = np.random.randint(len(x), max_samples_from_end) + 1
 
         dat[-samples_from_end : -samples_from_end + len(x)] = x
 

--- a/microwakeword/inception.py
+++ b/microwakeword/inception.py
@@ -20,7 +20,6 @@ import tensorflow as tf
 
 
 from microwakeword.layers import delay
-from microwakeword.layers import modes
 from microwakeword.layers import stream
 from microwakeword.layers import strided_drop
 from microwakeword.layers import sub_spectral_normalization
@@ -231,7 +230,7 @@ def spectrogram_slices_dropped(flags):
     return spectrogram_slices_dropped
 
 
-def model(flags, config):
+def model(flags, shape, batch_size):
     """Inception model.
 
     It is based on paper:
@@ -245,8 +244,8 @@ def model(flags, config):
       Keras model for training
     """
     input_audio = tf.keras.layers.Input(
-        shape=modes.get_input_data_shape(config, modes.Modes.TRAINING),
-        batch_size=config["batch_size"],
+        shape=shape,
+        batch_size=batch_size,
     )
     net = input_audio
 

--- a/microwakeword/inception.py
+++ b/microwakeword/inception.py
@@ -210,6 +210,27 @@ def model_parameters(parser_nn):
     )
 
 
+def spectrogram_slices_dropped(flags):
+    """Computes the number of spectrogram slices dropped due to valid padding.
+
+    Args:
+        flags: data/model parameters
+
+    Returns:
+        int: number of spectrogram slices dropped
+    """
+    spectrogram_slices_dropped = 0
+
+    for kernel_size in parse(flags.cnn1_kernel_sizes):
+        spectrogram_slices_dropped += kernel_size - 1
+    for kernel_size, dilation in zip(
+        parse(flags.cnn2_kernel_sizes), parse(flags.cnn2_dilation)
+    ):
+        spectrogram_slices_dropped += 2 * dilation * (kernel_size - 1)
+
+    return spectrogram_slices_dropped
+
+
 def model(flags, config):
     """Inception model.
 

--- a/microwakeword/model_train_eval.py
+++ b/microwakeword/model_train_eval.py
@@ -178,9 +178,8 @@ if __name__ == "__main__":
 
     config["spectrogram_length"] += spectrogram_slices_dropped
 
-    model = inception.model(flags, config)
     logging.info(model.summary())
-
+    
     logging.set_verbosity(flags.verbosity)
 
     data_processor = input_data.FeatureHandler(config)

--- a/microwakeword/model_train_eval.py
+++ b/microwakeword/model_train_eval.py
@@ -230,6 +230,10 @@ if __name__ == "__main__":
         if flags.model_name == "inception":
             model = inception.model(flags, config)
 
+        model.load_weights(
+            os.path.join(config["train_dir"], flags.use_weights)
+        ).expect_partial()
+
     if flags.test_tf_nonstreaming or flags.test_tflite_nonstreaming:
         # Save the nonstreaming model to disk
         logging.info("Saving nonstreaming model")
@@ -239,7 +243,6 @@ if __name__ == "__main__":
             config,
             "non_stream",
             modes.Modes.NON_STREAM_INFERENCE,
-            weights_name=flags.use_weights,
         )
 
     if flags.test_tf_nonstreaming:
@@ -287,7 +290,6 @@ if __name__ == "__main__":
             config,
             "stream_state_internal",
             modes.Modes.STREAM_INTERNAL_STATE_INFERENCE,
-            weights_name=flags.use_weights,
         )
 
     if flags.test_tflite_streaming:

--- a/microwakeword/model_train_eval.py
+++ b/microwakeword/model_train_eval.py
@@ -168,18 +168,11 @@ if __name__ == "__main__":
         )
 
     config["spectrogram_length_final_layer"] = config["spectrogram_length"]
-    spectrogram_slices_dropped = 0
 
     # Load model
     if flags.model_name == "inception":
-        model = model = inception.model(flags, config)
-
-        for kernel_size in parse(flags.cnn1_kernel_sizes):
-            spectrogram_slices_dropped += kernel_size - 1
-        for kernel_size, dilation in zip(
-            parse(flags.cnn2_kernel_sizes), parse(flags.cnn2_dilation)
-        ):
-            spectrogram_slices_dropped += 2 * dilation * (kernel_size - 1)
+        model = inception.model(flags, config)
+        spectrogram_slices_dropped = inception.spectrogram_slices_dropped(flags)
     else:
         raise ValueError("Unknown model type: {}".format(flags.model_name))
 

--- a/microwakeword/model_train_eval.py
+++ b/microwakeword/model_train_eval.py
@@ -22,10 +22,11 @@ import yaml
 from absl import logging
 
 import microwakeword.data as input_data
-import microwakeword.inception as inception
 import microwakeword.train as train
 import microwakeword.test as test
 import microwakeword.utils as utils
+
+import microwakeword.inception as inception
 
 from microwakeword.layers import modes
 
@@ -176,6 +177,7 @@ def evaluate_model(
     tflite_output_folders = []
     tflite_filenames = []
     tflite_testing_datasets = []
+    tflite_quantize = []
 
     if test_tflite_nonstreaming:
         tflite_log_strings.append("nonstreaming model")
@@ -183,6 +185,7 @@ def evaluate_model(
         tflite_output_folders.append("tflite_non_stream")
         tflite_filenames.append("non_stream.tflite")
         tflite_testing_datasets.append(["testing"])
+        tflite_quantize.append(False)
 
     if test_tflite_streaming:
         tflite_log_strings.append("streaming model")
@@ -190,6 +193,7 @@ def evaluate_model(
         tflite_output_folders.append("tflite_stream_state_internal")
         tflite_filenames.append("stream_state_internal.tflite")
         tflite_testing_datasets.append(["testing", "testing_ambient"])
+        tflite_quantize.append(False)
 
     if test_tflite_streaming_quantized:
         tflite_log_strings.append("quantized streaming model")
@@ -197,13 +201,22 @@ def evaluate_model(
         tflite_output_folders.append("tflite_stream_state_internal_quant")
         tflite_filenames.append("stream_state_internal_quant.tflite")
         tflite_testing_datasets.append(["testing", "testing_ambient"])
+        tflite_quantize.append(True)
 
-    for log_string, source_folder, output_folder, filename, testing_datasets in zip(
+    for (
+        log_string,
+        source_folder,
+        output_folder,
+        filename,
+        testing_datasets,
+        quantize,
+    ) in zip(
         tflite_log_strings,
         tflite_source_folders,
         tflite_output_folders,
         tflite_filenames,
         tflite_testing_datasets,
+        tflite_quantize,
     ):
         logging.info("Converting " + log_string + " to TFLite")
 
@@ -213,6 +226,7 @@ def evaluate_model(
             os.path.join(config["train_dir"], source_folder),
             os.path.join(config["train_dir"], output_folder),
             filename,
+            quantize=quantize,
         )
 
         for dataset in testing_datasets:

--- a/microwakeword/model_train_eval.py
+++ b/microwakeword/model_train_eval.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 import argparse
-import ast
-import json
 import os
 import yaml
 from absl import logging

--- a/microwakeword/train.py
+++ b/microwakeword/train.py
@@ -15,16 +15,12 @@
 # limitations under the License.
 
 import os
-import pprint
 
 from absl import logging
 from collections import deque
 
 import numpy as np
 import tensorflow as tf
-
-import microwakeword.inception as inception
-import microwakeword.utils as utils
 
 import microwakeword.test as test
 
@@ -94,12 +90,7 @@ def validate_nonstreaming(config, data_processor, model, test_set):
     return metrics
 
 
-def train(flags, config, data_processor):
-    model = inception.model(flags, config)
-
-    utils.save_model_summary(model, config["train_dir"])
-
-    logging.info(model.summary())
+def train(model, config, data_processor):
 
     # Assign default training settings if not set in the configuration yaml
     if not (training_steps_list := config.get("training_steps")):
@@ -139,9 +130,6 @@ def train(flags, config, data_processor):
     pad_list_with_last_entry(freq_mask_count_list, training_step_iterations)
     pad_list_with_last_entry(positive_class_weight_list, training_step_iterations)
     pad_list_with_last_entry(negative_class_weight_list, training_step_iterations)
-
-    with open(os.path.join(config["train_dir"], "flags.txt"), "wt") as f:
-        pprint.pprint(flags, stream=f)
 
     loss = tf.keras.losses.BinaryCrossentropy(from_logits=False)
     optimizer = tf.keras.optimizers.legacy.Adam()

--- a/microwakeword/train.py
+++ b/microwakeword/train.py
@@ -385,6 +385,9 @@ def train(model, config, data_processor):
                 (best_maximization_quantity * 100),
             )
 
+    # Save checkpoint after training
+    checkpoint.save(file_prefix=checkpoint_prefix)
+
     testing_fingerprints, testing_ground_truth, _ = data_processor.get_data(
         "testing",
         batch_size=config["batch_size"],

--- a/microwakeword/utils.py
+++ b/microwakeword/utils.py
@@ -378,7 +378,7 @@ def convert_saved_model_to_tflite(
     open(path_to_output, "wb").write(tflite_model)
 
 
-def convert_model_saved(model, config, folder, mode, weights_name="best_weights"):
+def convert_model_saved(model, config, folder, mode):
     """Convert model to streaming and non streaming SavedModel.
 
     Args:
@@ -386,10 +386,7 @@ def convert_model_saved(model, config, folder, mode, weights_name="best_weights"
         config: dictionary containing microWakeWord training configuration
         folder: folder where converted model will be saved
         mode: inference mode
-        weights_name: file name with model weights
     """
-
-    model.load_weights(os.path.join(config["train_dir"], weights_name)).expect_partial()
 
     path_model = os.path.join(config["train_dir"], folder)
     if not os.path.exists(path_model):

--- a/microwakeword/utils.py
+++ b/microwakeword/utils.py
@@ -256,7 +256,7 @@ def to_streaming_inference(model_non_stream, config, mode):
     Returns:
       Keras inference model of inference_type
     """
-    # tf.keras.backend.set_learning_phase(0)
+
     input_data_shape = modes.get_input_data_shape(config, mode)
 
     # get input data type and use it for input streaming type
@@ -392,7 +392,7 @@ def convert_model_saved(model, config, folder, mode):
     if not os.path.exists(path_model):
         os.makedirs(path_model)
     try:
-        # convert trained model to SavedModel
+        # Convert trained model to SavedModel
         model_to_saved(model, config, path_model, mode)
     except IOError as e:
         logging.warning("FAILED to write file: %s", e)


### PR DESCRIPTION
Refactors code around loading models to reduce repeated code over multiple files and to improve the organization of ``model_train_eval.py``. Adding a new model architecture now only requires 4 lines of new code in 1 file.