### PR TITLE
init features_offset variable for cases where data_length > features_…

### DIFF
--- a/microwakeword/data.py
+++ b/microwakeword/data.py
@@ -148,6 +148,7 @@ def fixed_length_spectrogram(
         fixed length spectrogram after truncating or padding
     """
     data_length = spectrogram.shape[0]
+    features_offset = 0
     if data_length > features_length:
         if truncation_strategy == "random":
             features_offset = np.random.randint(0, data_length - features_length)


### PR DESCRIPTION
when training with datasets with truncation set to "split" and when the datalength is greater than the featuers length configured, the features_offset variable is left un-initialized and is later used un-initialized which crashes the script. This commit fixes that...