### PR TITLE
Use the main branch in the training notebook

### DIFF
--- a/notebooks/basic_training_notebook.ipynb
+++ b/notebooks/basic_training_notebook.ipynb
@@ -37,7 +37,7 @@
     "# `audio-metadata` is installed from a fork to unpin `attrs` from a version that breaks Jupyter\n",
     "!pip install 'git+https://github.com/whatsnowplaying/audio-metadata@d4ebb238e6a401bb1a5aaaac60c9e2b3cb30929f'\n",
     "\n",
-    "!git clone -b november-update https://github.com/kahrendt/microWakeWord\n",
+    "!git clone -b https://github.com/kahrendt/microWakeWord\n",
     "!pip install -e ./microWakeWord"
    ]
   },
@@ -538,7 +538,8 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -551,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Trained models weren't able to be properly quantized to run on the device, which was fixed in #39. However the training notebook still cloned a branch with the bug, so this PR changes it to use the main branch.

Fixes #46, #47 if the model is converted with the new notebook.