### PR TITLE
Fix for the fma_dataset variable

### DIFF
--- a/notebooks/basic_training_notebook.ipynb
+++ b/notebooks/basic_training_notebook.ipynb
@@ -185,9 +185,9 @@
     "\n",
     "    # Save clips to 16-bit PCM wav files\n",
     "    fma_dataset = datasets.Dataset.from_dict({\"audio\": [str(i) for i in Path(\"fma/fma_small\").glob(\"**/*.mp3\")]})\n",
-    "    audioset_dataset = audioset_dataset.cast_column(\"audio\", datasets.Audio(sampling_rate=16000))\n",
-    "    for row in tqdm(audioset_dataset):\n",
-    "        name = row['audio']['path'].split('/')[-1].replace(\".flac\", \".wav\")\n",
+    "    fma_dataset = fma_dataset.cast_column(\"audio\", datasets.Audio(sampling_rate=16000))\n",
+    "    for row in tqdm(fma_dataset):\n",
+    "        name = row['audio']['path'].split('/')[-1].replace(\".mp3\", \".wav\")\n",
     "        scipy.io.wavfile.write(os.path.join(output_dir, name), 16000, (row['audio']['array']*32767).astype(np.int16))\n"
    ]
   },


### PR DESCRIPTION
Ran into an error when I went to recreate the fma dirs:

```
audioset_dataset = audioset_dataset.cast_column("audio", datasets.Audio(sampling_rate=16000))
                   ^^^^^^^^^^^^^^^^

NameError: name 'audioset_dataset' is not defined
```

Looks like for a normal run it's been re-using the variable, so you end up with 2 copies of the audioset dataset.  Confirmed this now gives me some random song clips in addition to the audioset wavs. 🎶 