### PR TITLE
Fix dependency install command in basic_training_notebook.ipynb

### DIFF
--- a/notebooks/basic_training_notebook.ipynb
+++ b/notebooks/basic_training_notebook.ipynb
@@ -37,7 +37,7 @@
     "# `audio-metadata` is installed from a fork to unpin `attrs` from a version that breaks Jupyter\n",
     "!pip install 'git+https://github.com/whatsnowplaying/audio-metadata@d4ebb238e6a401bb1a5aaaac60c9e2b3cb30929f'\n",
     "\n",
-    "!git clone -b https://github.com/kahrendt/microWakeWord\n",
+    "!git clone https://github.com/kahrendt/microWakeWord\n",
     "!pip install -e ./microWakeWord"
    ]
   },


### PR DESCRIPTION
This PR fixes the dependency installation process in `basic_training_notebook.ipynb` Jupyter Notebook. 
The argument `-b` of the `git clone` command without branch name specified leads to error.