### PR TITLE
fix: replace deprecated np.trapz with np.trapezoid

### DIFF
--- a/microwakeword/test.py
+++ b/microwakeword/test.py
@@ -388,7 +388,7 @@ def tflite_streaming_model_roc(
 
     path = os.path.join(config["train_dir"], folder)
     with open(os.path.join(path, accuracy_name), "wt") as fd:
-        auc = np.trapz(y_coordinates, x_coordinates)
+        auc = np.trapezoid(y_coordinates, x_coordinates)
         auc_string = "AUC {:.5f}".format(auc)
         logging.info(auc_string)
         fd.write(auc_string + "\n")

--- a/microwakeword/train.py
+++ b/microwakeword/train.py
@@ -151,7 +151,7 @@ def validate_nonstreaming(config, data_processor, model, test_set):
 
         # Use trapezoid rule to estimate the area under the curve, then divide by 2.0 to get the average recall
         average_viable_recall = (
-            np.trapz(np.flip(y_coordinates), np.flip(x_coordinates)) / 2.0
+            np.trapezoid(np.flip(y_coordinates), np.flip(x_coordinates)) / 2.0
         )
 
         metrics["recall_at_no_faph"] = recall_at_no_faph


### PR DESCRIPTION
As np.trapz has been deprecated now (triggering AttributeError), we need to change the calls to np.trapezoid.