### PR TITLE
Fix TF 2.21 and NumPy 2 compatibility in training

### DIFF
--- a/microwakeword/test.py
+++ b/microwakeword/test.py
@@ -388,7 +388,7 @@ def tflite_streaming_model_roc(
 
     path = os.path.join(config["train_dir"], folder)
     with open(os.path.join(path, accuracy_name), "wt") as fd:
-        auc = np.trapz(y_coordinates, x_coordinates)
+        auc = np.trapezoid(y_coordinates, x_coordinates)
         auc_string = "AUC {:.5f}".format(auc)
         logging.info(auc_string)
         fd.write(auc_string + "\n")

--- a/microwakeword/train.py
+++ b/microwakeword/train.py
@@ -151,7 +151,7 @@ def validate_nonstreaming(config, data_processor, model, test_set):
 
         # Use trapezoid rule to estimate the area under the curve, then divide by 2.0 to get the average recall
         average_viable_recall = (
-            np.trapz(np.flip(y_coordinates), np.flip(x_coordinates)) / 2.0
+            np.trapezoid(np.flip(y_coordinates), np.flip(x_coordinates)) / 2.0
         )
 
         metrics["recall_at_no_faph"] = recall_at_no_faph

--- a/microwakeword/train.py
+++ b/microwakeword/train.py
@@ -70,7 +70,7 @@ def validate_nonstreaming(config, data_processor, model, test_set):
     metrics["ambient_false_positives_per_hour"] = 0
     metrics["average_viable_recall"] = 0
 
-    test_set_fp = result["fp"].numpy()
+    test_set_fp = np.asarray(result["fp"])
 
     if data_processor.get_mode_size("validation_ambient") > 0:
         (
@@ -101,9 +101,9 @@ def validate_nonstreaming(config, data_processor, model, test_set):
 
         # Other than the false positive rate, all other metrics are accumulated across
         # both test sets
-        all_true_positives = ambient_predictions["tp"].numpy()
-        ambient_false_positives = ambient_predictions["fp"].numpy() - test_set_fp
-        all_false_negatives = ambient_predictions["fn"].numpy()
+        all_true_positives = np.asarray(ambient_predictions["tp"])
+        ambient_false_positives = np.asarray(ambient_predictions["fp"]) - test_set_fp
+        all_false_negatives = np.asarray(ambient_predictions["fn"])
 
         metrics["auc"] = ambient_predictions["auc"]
         metrics["loss"] = ambient_predictions["loss"]


### PR DESCRIPTION
## Summary

Two small bumps that make `microwakeword.model_train_eval` complete a validation cycle on a current Python data-science stack (TensorFlow 2.21, NumPy 2.x).

Without these patches, training crashes at the first validation eval. With them, validation runs to completion and `best_weights.weights.h5` is produced.

## Changes

1. **`train.py`** — `model.evaluate(return_dict=True)` in TF ≥ 2.21 returns plain ndarrays/scalars for each metric, not `EagerTensor`s, so the `.numpy()` calls on `result["fp"]`, `ambient_predictions["tp"]`, `ambient_predictions["fp"]`, and `ambient_predictions["fn"]` raise `AttributeError: 'numpy.ndarray' object has no attribute 'numpy'`. Switched to `np.asarray(...)`, which is a no-op on ndarrays and still works on tensors — covers both old and new return shapes.

2. **`train.py` and `test.py`** — `np.trapz` was removed in NumPy 2.0 (`np.trapezoid` is the documented replacement with the same signature).

## Tested

Ran end-to-end on Ubuntu 24.04 / Python 3.12 with:

- `tensorflow == 2.21.0`
- `numpy == 2.x`
- `datasets == 2.21.0`

Validation now reaches Step 0 (Acc 0.988 / Recall 0.884 / Precision 0.947 on a 5000-sample synthetic positive set) without errors, and `best_weights.weights.h5` is written by the trainer.

Happy to add a CI smoke run or adjust the wording if helpful.